### PR TITLE
Fixes the annotations disappearing when you re-visit a view controller that has the mapview in it.

### DIFF
--- a/Pod/Classes/TSClusterMapView.m
+++ b/Pod/Classes/TSClusterMapView.m
@@ -77,7 +77,9 @@ static NSMutableSet *_clusterAnnotationsPool;
 }
 
 - (void)initHelpers {
-    
+    if(_clusterAnnotationsPool)
+        [_clusterAnnotationsPool removeAllObjects];
+
     [self setDefaults];
     
     _preClusterOperationQueue = [[NSOperationQueue alloc] init];


### PR DESCRIPTION
This should fix: https://github.com/ashare80/TSClusterMapView/issues/25
I'm not 100% sure of what the consequences might be, but this would resolve that particular issue.

Here's how you reproduce the bug:
- Create a MapViewController with the TSClusterMapView in it.
- Create a NavigationController with a ViewController with a button that takes you to the MapViewController
- Tap the button to go to the MapViewController
  [All annotations show up correctly]
- Tap the back button
- Tap the button to go to the MapViewController again
  [No annotations show up] <--- Bug
