### PR TITLE
detailCalloutAccessoryView is ignored

### DIFF
--- a/Pod/Classes/TSClusterAnnotationView.m
+++ b/Pod/Classes/TSClusterAnnotationView.m
@@ -65,6 +65,7 @@
     self.selected = annotationView.selected;
     self.leftCalloutAccessoryView = annotationView.leftCalloutAccessoryView;
     self.rightCalloutAccessoryView = annotationView.rightCalloutAccessoryView;
+    self.detailCalloutAccessoryView = annotationView.detailCalloutAccessoryView;
     self.draggable = annotationView.isDraggable;
     
     return viewToCache;


### PR DESCRIPTION
It's just ignored (e.g. for [custom callouts](https://stackoverflow.com/questions/17772108/custom-mkannotation-callout-bubble-with-button)).